### PR TITLE
Fix tech helpers: Use fallback of 5nm if PDK does not configure default_grids in *.lyt file

### DIFF
--- a/grain.xml
+++ b/grain.xml
@@ -3,7 +3,7 @@
  <name>KLayoutPluginUtils</name>
  <token/>
  <hidden>true</hidden>
- <version>0.12</version>
+ <version>0.13</version>
  <api-version/>
  <title>Utility Library for KLayout Plugins</title>
  <doc>Utility Python package used by various IIC KLayout Plugins</doc>

--- a/python/klayout_plugin_utils/tech_helpers.py
+++ b/python/klayout_plugin_utils/tech_helpers.py
@@ -24,4 +24,9 @@ def drc_tech_grid_um() -> float:
     Used for DRC (offgrid errors)
     """
     cv = pya.CellView.active()
-    return cv.layout().technology().default_grid()
+    default_grid = cv.layout().technology().default_grid()
+    # FIXME: there should be a KLayout API method for getting the effective DRC default grid
+    #        for now we just use the default grid list (the entry with !)
+    if default_grid <= 0.00001:  # some technologies have no default grid, e.g. GF180mcuD
+        default_grid = 0.005  # fallback to 5nm
+    return default_grid


### PR DESCRIPTION
Necessary to fix https://github.com/iic-jku/klayout-align-tool/issues/36